### PR TITLE
Add Photo Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ cmake-build-*/
 # specific files
 compile_commands.json
 scripts/binary_to_compressed_c
+/.vs
+/CMakeSettings.json

--- a/src/prime/CActorMP1.hpp
+++ b/src/prime/CActorMP1.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "prime/Math.hpp"
+
+class CActorMP1 {
+  public:
+  CTransform4f& GetTransform() const;
+  CTransform4f SetTransform(const CTransform4f& transform);
+};

--- a/src/prime/CFirstPersonCamera.hpp
+++ b/src/prime/CFirstPersonCamera.hpp
@@ -24,3 +24,12 @@ class CCameraManagerMP1 {
 public:
   static float GetDefaultFirstPersonVerticalFOV();
 };
+
+class STonemapParams {
+public:
+  inline float* inverseExposure() { return GetField<float>(this, 0x0); };
+};
+
+namespace NTonemap {
+  void build_tonemap_eval_params(STonemapParams const&);
+}

--- a/src/prime/CFirstPersonCamera.hpp
+++ b/src/prime/CFirstPersonCamera.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "program/GetField.hpp"
+#include "prime/CActorMP1.hpp"
+
+class CStateManager;
+
+class CGameCamera : public CActorMP1 {};
+
+class CGameCameraMP1: public CGameCamera {
+public:
+  inline float* GetCurrentFOV() {
+      return GetField<float>(this, 0x25c);
+  };
+  void UpdateFOV(float dt);
+};
+
+class CFirstPersonCameraMP1 : public CGameCameraMP1 {
+public:
+  void Think(float, CStateManager&);
+};
+
+class CCameraManagerMP1 {
+public:
+  static float GetDefaultFirstPersonVerticalFOV();
+};

--- a/src/prime/CGameState.hpp
+++ b/src/prime/CGameState.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CObjectId.hpp"
+#include "program/GetField.hpp"
 #include "types.h"
 
 namespace rstl {
@@ -80,18 +81,33 @@ public:
   }
 };
 
+class CStateManagerGameLogicMP1;
+class CStateManager {
+public:
+  CGameState* GameState();
+
+  inline CStateManagerGameLogicMP1* GameLogic() {
+    return GetField<CStateManagerGameLogicMP1>(this, 0x4e0150);
+  }
+};
+
+class CStateManagerUpdateAccess;
+
 class CPlayerStateMP1;
 class CGameStateMP1 {
 public:
 //  CPlayerStateMP1* GetPlayerState() const;
   CPlayerStateMP1* PlayerState();
-  inline CPlayerStateMP1* GetPlayerState_2() { return reinterpret_cast<CPlayerStateMP1*>(reinterpret_cast<size_t>(this) + 0x20); }
+  inline CPlayerStateMP1* GetPlayerState_2() { return GetField<CPlayerStateMP1>(this, 0x20); }
 };
 extern CGameStateMP1* gpGameState;
 
 class CPlayerMP1;
 class CStateManagerGameLogicMP1 {
 public:
-  static CPlayerStateMP1 *PlayerState();
-  CPlayerMP1 *PlayerActor();
+  enum class EGameState : uint32_t { Running, SoftPaused, Paused };
+  void GameMainLoop(CStateManager& mgr, CStateManagerUpdateAccess& mgrUpdAcc, float dt);
+  static CPlayerStateMP1* PlayerState();
+  CPlayerMP1* PlayerActor();
+  void SetGameState(EGameState state);
 };

--- a/src/prime/CPlayerMP1.hpp
+++ b/src/prime/CPlayerMP1.hpp
@@ -48,11 +48,22 @@ public:
 //  inline float &GetB() const { return *GetField<float>(this, 0x4); }
 };
 
+class CTweakPlayerMP1 {
+public:
+  inline float GetMaxFreeLookPitchAngle() { return *GetField<float>(this, 0x138); }
+};
+
+extern CTweakPlayerMP1* gpTweakPlayer;
+
 class CFinalInput;
 class CPlayerMP1 : public CPhysicsActorMP1 {
 public:
+  enum class EOrbitBrokenType : uint32_t;
+  void BreakOrbit(EOrbitBrokenType, CStateManager&);
+  inline float* GetFreeLookPitchAngle() { return GetField<float>(this, 0x5cc); };
   inline CMorphBallMP1 *GetMorphBall() { return *GetField<CMorphBallMP1*>(this, 0x9d0); }
   inline EPlayerMovementState GetMoveState() { return *GetField<EPlayerMovementState>(this, 0x3f0); }
   CHealthInfoMP1 &HealthInfo(CStateManager &mgr);
   void ProcessInput(const CFinalInput&, CStateManager&);
+  void RenderGun(const CStateManager& mgr, const CVector3f& pos) const;
 };

--- a/src/prime/CPlayerMP1.hpp
+++ b/src/prime/CPlayerMP1.hpp
@@ -2,12 +2,7 @@
 
 #include "prime/Math.hpp"
 #include "program/GetField.hpp"
-
-class CActorMP1 {
-public:
-  CTransform4f &GetTransform() const;
-  CTransform4f SetTransform(const CTransform4f &transform);
-};
+#include "prime/CActorMP1.hpp"
 
 class CStateManager;
 class CPhysicsActorMP1 : public CActorMP1 {

--- a/src/prime/CSamusHudMP1.hpp
+++ b/src/prime/CSamusHudMP1.hpp
@@ -1,8 +1,25 @@
 #pragma once
 
+namespace rstl {
+  template <class T, typename storage, T val>
+  struct enum_bit_field;
+};
+
 class CStateManager;
+
+class CGuiCamera;
+
+class CAutoMapperMP1 {
+public:
+  void Update(float f1, const CStateManager &csm, const CGuiCamera& cgc, float f2, bool b1);
+};
+
 
 class CSamusHudMP1 {
 public:
+  enum class EHudDrawFilter : uint32_t;
+
+  void Draw(const CStateManager &stateManager, float alpha, uint32_t param_3, const rstl::enum_bit_field<CSamusHudMP1::EHudDrawFilter, unsigned int, (CSamusHudMP1::EHudDrawFilter)3> &hudDrawFilterFlags) const;
+  void DrawHelmet(const CStateManager& stateManager, float camYOffset) const;
   void DrawTargetingReticle(const CStateManager&) const;
 };

--- a/src/program/InventoryMenu.hpp
+++ b/src/program/InventoryMenu.hpp
@@ -4,14 +4,6 @@
 #include "prime/CPlayerStateMP1.hpp"
 #include "prime/CGameState.hpp"
 
-class CStateManager {
-public:
-  CGameState *GameState();
-
-  inline CStateManagerGameLogicMP1* GameLogic() {
-      return reinterpret_cast<CStateManagerGameLogicMP1*>(reinterpret_cast<size_t>(this) + 0x4e0150);
-  }
-};
 namespace GUI {
   void drawInventoryMenu();
 }

--- a/src/program/PhotoModeMenu.cpp
+++ b/src/program/PhotoModeMenu.cpp
@@ -12,6 +12,11 @@
 
 namespace GUI {
   bool is_time_stopped = false;
+  const float defaultFirstPersonFov = CCameraManagerMP1::GetDefaultFirstPersonVerticalFOV();
+  float verticalFov = defaultFirstPersonFov;
+  bool shouldUpdateVerticalFov = false;
+  float viewRoll = 0.f;
+  CGameCameraMP1* fpCamera = nullptr;
 
   const bool shouldHideAll() {
       return PATCH_CONFIG.hide_hud_when_time_stopped && is_time_stopped;
@@ -23,6 +28,32 @@ namespace GUI {
       REQ_CONFIG_IF(ImGui::Checkbox("Hide arm cannon", &PATCH_CONFIG.hide_cannon));
       REQ_CONFIG_IF(ImGui::Checkbox("Hide HUD", &PATCH_CONFIG.hide_hud));
       REQ_CONFIG_IF(ImGui::Checkbox("Auto-hide HUD & cannon when time stopped", &PATCH_CONFIG.hide_hud_when_time_stopped));
+
+      // NOT SAVED
+      // Vertical FOV
+      ImGui::PushID("VerticalFOV");
+      if (ImGui::DragFloat("", &verticalFov, 1.0, 1.0, 170.f, "%.2f")) {
+        shouldUpdateVerticalFov = true;
+      }
+      ImGui::SameLine();
+      if (ImGui::Button("Reset")) {
+        verticalFov = defaultFirstPersonFov;
+        shouldUpdateVerticalFov = true;
+      }
+      ImGui::SameLine();
+      ImGui::Text("Vertical FOV");
+      ImGui::PopID();
+
+      // View Roll
+      ImGui::PushID("ViewRoll");
+      ImGui::DragFloat("", &viewRoll, 1.0, -90.f, 90.f, "%.2f");
+      ImGui::SameLine();
+      if (ImGui::Button("Reset")) {
+        viewRoll = 0.f;
+      }
+      ImGui::SameLine();
+      ImGui::Text("View Roll");
+      ImGui::PopID();
 
       ImGui::TreePop();
     }

--- a/src/program/PhotoModeMenu.cpp
+++ b/src/program/PhotoModeMenu.cpp
@@ -1,0 +1,30 @@
+#include "PhotoModeMenu.hpp"
+#include "patches.hpp"
+#include "imgui.h"
+
+#define REQ_CONFIG_IF(cond, ...)                                                                                       \
+  {                                                                                                                    \
+    if (cond) {                                                                                                        \
+      PATCH_CONFIG.RequestConfigSave();                                                                                \
+      __VA_ARGS__                                                                                                      \
+    }                                                                                                                  \
+  }
+
+namespace GUI {
+  bool is_time_stopped = false;
+
+  const bool shouldHideAll() {
+      return PATCH_CONFIG.hide_hud_when_time_stopped && is_time_stopped;
+  }
+
+  void drawPhotoModeMenu() {
+    if (ImGui::TreeNode("Photo Mode")) {
+      REQ_CONFIG_IF(ImGui::Checkbox("Stop time (left stick + L)", &PATCH_CONFIG.enable_stop_time));
+      REQ_CONFIG_IF(ImGui::Checkbox("Hide arm cannon", &PATCH_CONFIG.hide_cannon));
+      REQ_CONFIG_IF(ImGui::Checkbox("Hide HUD", &PATCH_CONFIG.hide_hud));
+      REQ_CONFIG_IF(ImGui::Checkbox("Auto-hide HUD & cannon when time stopped", &PATCH_CONFIG.hide_hud_when_time_stopped));
+
+      ImGui::TreePop();
+    }
+  }
+}

--- a/src/program/PhotoModeMenu.cpp
+++ b/src/program/PhotoModeMenu.cpp
@@ -17,6 +17,7 @@ namespace GUI {
   bool shouldUpdateVerticalFov = false;
   float viewRoll = 0.f;
   CGameCameraMP1* fpCamera = nullptr;
+  float exposure;
 
   const bool shouldHideAll() {
       return PATCH_CONFIG.hide_hud_when_time_stopped && is_time_stopped;
@@ -53,6 +54,17 @@ namespace GUI {
       }
       ImGui::SameLine();
       ImGui::Text("View Roll");
+      ImGui::PopID();
+
+      // Exposure
+      ImGui::PushID("Exposure");
+      ImGui::DragFloat("", &exposure, 0.1, -2.5, 2.5, "%.2f");
+      ImGui::SameLine();
+      if (ImGui::Button("Reset")) {
+        exposure = 0.f;
+      }
+      ImGui::SameLine();
+      ImGui::Text("Exposure");
       ImGui::PopID();
 
       ImGui::TreePop();

--- a/src/program/PhotoModeMenu.hpp
+++ b/src/program/PhotoModeMenu.hpp
@@ -9,6 +9,7 @@ namespace GUI {
   extern bool shouldUpdateVerticalFov;
   extern float viewRoll;
   extern CGameCameraMP1* fpCamera;
+  extern float exposure;
 
   const bool shouldHideAll();
   void drawPhotoModeMenu();

--- a/src/program/PhotoModeMenu.hpp
+++ b/src/program/PhotoModeMenu.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "prime/Math.hpp"
+
+namespace GUI {
+  extern bool is_time_stopped;
+
+  const bool shouldHideAll();
+  void drawPhotoModeMenu();
+} // namespace GUI

--- a/src/program/PhotoModeMenu.hpp
+++ b/src/program/PhotoModeMenu.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
 #include "prime/Math.hpp"
+#include "prime/CFirstPersonCamera.hpp"
 
 namespace GUI {
   extern bool is_time_stopped;
+  extern float verticalFov;
+  extern bool shouldUpdateVerticalFov;
+  extern float viewRoll;
+  extern CGameCameraMP1* fpCamera;
 
   const bool shouldHideAll();
   void drawPhotoModeMenu();

--- a/src/program/main.cpp
+++ b/src/program/main.cpp
@@ -15,6 +15,7 @@
 #include "PlayerMenu.hpp"
 #include "ProductionFlagMenu.hpp"
 #include "InputWindow.hpp"
+#include "PhotoModeMenu.hpp"
 
 #define IMGUI_ENABLED true
 
@@ -86,6 +87,7 @@ void drawDebugWindow() {
       ImGui::TreePop();
     }
 
+    GUI::drawPhotoModeMenu();
     GUI::drawInventoryMenu();
     GUI::drawPlayerMenu();
 //  GUI::drawProductionFlagMenu();

--- a/src/program/patches.hpp
+++ b/src/program/patches.hpp
@@ -26,6 +26,11 @@ struct PatchConfig {
 
   bool hide_reticle = false;
 
+  bool enable_stop_time = false;
+  bool hide_cannon = false;
+  bool hide_hud = false;
+  bool hide_hud_when_time_stopped = true;
+
   void RequestConfigSave();
   bool ShouldSave();
 


### PR DESCRIPTION
I've found Practice Mod to be really useful for taking in-game screenshots, and I wanted to try expanding those capabilities with some extra features. This PR adds the ability to stop time and remove all first-person HUD elements; a demonstration of these features can be seen [here](https://www.youtube.com/watch?v=LC1HfUlzxKk).

I also did some minor cleanup, mostly just moving CStateManager into the CGameState header file instead of InventoryMenu.

Ideally I'd like to continue adding on to this, e.g. with the ability to change the camera exposure, adjust camera roll, etc., but I felt like this was big enough for a PR as it is. I do realize this is kind of out of scope for the original goal of Practice Mod- if you'd prefer I fork this into a separate mod instead, just let me know and I'll happily credit you.