### PR TITLE
Add death feature in player menu

### DIFF
--- a/src/prime/CFirstPersonCamera.hpp
+++ b/src/prime/CFirstPersonCamera.hpp
@@ -22,6 +22,14 @@ public:
 
 class CCameraManagerMP1 {
 public:
+  inline bool IsInCinematicCamera()
+  {
+    // camera count
+    if(*GetField<int>(this, 0x8) != 0) {
+      return true;
+    }
+    return *GetField<int>(this, 0x18) != 0;
+  }
   static float GetDefaultFirstPersonVerticalFOV();
 };
 

--- a/src/prime/CGameState.hpp
+++ b/src/prime/CGameState.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "CObjectId.hpp"
+#include "prime/CFirstPersonCamera.hpp"
+#include "prime/CWorldMP1.hpp"
 #include "program/GetField.hpp"
 #include "types.h"
 
@@ -89,6 +91,12 @@ public:
   inline CStateManagerGameLogicMP1* GameLogic() {
     return GetField<CStateManagerGameLogicMP1>(this, 0x4e0150);
   }
+  inline CCameraManagerMP1* GetCameraManager() { 
+    auto* ptr = reinterpret_cast<size_t*>(reinterpret_cast<size_t>(this) + 0x4e0150);
+    if (ptr != nullptr)
+      return *reinterpret_cast<CCameraManagerMP1**>(reinterpret_cast<size_t>(*ptr) + 0x30);
+    return nullptr;
+  }
 };
 
 class CStateManagerUpdateAccess;
@@ -110,4 +118,7 @@ public:
   static CPlayerStateMP1* PlayerState();
   CPlayerMP1* PlayerActor();
   void SetGameState(EGameState state);
+
+  inline CWorldMP1* GetWorld() { return *GetField<CWorldMP1*>(this, 0x20); }
+  inline CCameraManagerMP1* GetCameraManager() { return *GetField<CCameraManagerMP1*>(this, 0x30); }
 };

--- a/src/prime/CPlayerStateMP1.hpp
+++ b/src/prime/CPlayerStateMP1.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+class CStateManager;
+
 class CPowerUp {
 public:
   int amount;
@@ -60,8 +62,10 @@ public:
   void SetPowerUp(EItemType type, int amount);
   int GetPowerUp(EItemType type);
   int GetItemCapacity(EItemType type) const;
+  void Kill(CStateManager&);
 
   inline CPowerUp* GetPowerups() { return reinterpret_cast<CPowerUp*>(reinterpret_cast<size_t>(this) + 0x44); }
+  inline bool IsPlayerAlive() { return (*reinterpret_cast<u8*>(this) & 1) == 1; }
 
   static int GetItemMax(EItemType type);
 //  _ZN15CPlayerStateMP110GetItemMaxE9EItemType

--- a/src/prime/CWorldMP1.hpp
+++ b/src/prime/CWorldMP1.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "program/GetField.hpp"
+#include "types.h"
+
+class CWorldMP1 {
+public:
+  inline int32_t GetLoadPhase() { return *GetField<int32_t>(this, 8); }
+};

--- a/src/program/PlayerMenu.cpp
+++ b/src/program/PlayerMenu.cpp
@@ -36,6 +36,11 @@ namespace GUI {
 //  u32 savedWorldAssetID{0};
 //  u32 savedAreaAssetID{0};
 
+  bool isInCutscene = true;
+  bool alive = false;
+  bool kill = false;
+  int32_t loadPhase = -1;
+
   void drawPlayerMenu() {
 //    CStateManager *stateManager = mostRecentStateManager;
 //    if (stateManager == nullptr) return;
@@ -124,6 +129,9 @@ namespace GUI {
 //        player->setFluidCounter((u32) fluidCounter);
 //      }
 //      ImGui::DragFloat("Water depth", player->getDepthUnderWater(), 1.f, -FLT_MAX, FLT_MAX, "%.3f", flags);
+      if (!isInCutscene && loadPhase == 4 && ImGui::Button("Death")) {
+        kill = alive;
+      }
 
       ImGui::TreePop();
     }

--- a/src/program/PlayerMenu.hpp
+++ b/src/program/PlayerMenu.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "prime/Math.hpp"
+#include "types.h"
 
 namespace GUI {
   extern bool hasDesiredPositionData;
@@ -16,6 +17,11 @@ namespace GUI {
   extern CAxisAngle lastKnownAngularVelocity;
 
   extern double desiredTime;
+
+  extern bool isInCutscene;
+  extern bool alive;
+  extern bool kill;
+  extern int32_t loadPhase;
 
   void drawPlayerMenu();
   void savePos();


### PR DESCRIPTION
## Adds a death button in player menu
It calls CPlayerState::Kill(CStateManager&) to tell that the player is not alive which triggers the death animation and brings you to the game over screen.